### PR TITLE
fix: Install prettier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10809,6 +10809,12 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prettier": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.2.tgz",
+      "integrity": "sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg==",
+      "dev": true
+    },
     "prettier-linter-helpers": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "full-icu": "^1.3.1",
     "husky": "^4.2.3",
     "jest": "^25.1.0",
+    "prettier": "^2.0.2",
     "semantic-release": "^17.0.4"
   },
   "dependencies": {


### PR DESCRIPTION
#### What is the goal of this change?
Install `prettier` as dependency.

#### Is there any issue related?
Husky's `pre-push` hook was wrong, because the dependency wasn't installed.

#### How does the changes address the issue?
The issue should be solved since prettier is a required dependency.
