### PR TITLE
fix(build): Build code on CI before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,8 @@ jobs:
           node-version: 12
       - name: Install dependencies
         run: npm install
+      - name: Build
+        run: npm build
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
#### What is the goal of this change?
Build the code before publishing package to npm.

#### Is there any issue related?
The package is unusable because the `/dist` folder can't be found.

#### How does the changes address the issue?
Building the code before publishing will solve the problem.
