### PR TITLE
fix(scripts): Update npm scripts on CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: npm install
       - name: Test code
-        run: npm test
+        run: npm run test
   release:
     name: Semantic Release
     runs-on: ubuntu-18.04
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: npm install
       - name: Build
-        run: npm build
+        run: npm run build
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
#### What is the goal of this change?
Updated npm scripts call on CI environment.

#### Is there any issue related?
`npm build` wasn't being called due to how npm deals with the build script.

#### How does the changes address the issue?
I've added `npm run build` on CI pipelines, so it can call our script - done that also to test script, to keep the patern.
